### PR TITLE
Reduce the amount of layers for Foreman and Candlepin

### DIFF
--- a/container-images/candlepin/Containerfile
+++ b/container-images/candlepin/Containerfile
@@ -1,10 +1,9 @@
 FROM quay.io/centos/centos:stream9
-
-RUN dnf -y update
-RUN dnf -y install \
+RUN dnf -y update && \
+    dnf clean all
+RUN dnf -y --nodocs install \
     https://yum.theforeman.org/candlepin/4.4/el9/x86_64/candlepin-4.4.14-1.el9.noarch.rpm \
-    https://yum.theforeman.org/candlepin/4.4/el9/x86_64/candlepin-selinux-4.4.14-1.el9.noarch.rpm
-
-RUN dnf clean all
+    https://yum.theforeman.org/candlepin/4.4/el9/x86_64/candlepin-selinux-4.4.14-1.el9.noarch.rpm && \ 
+    dnf clean all
 
 CMD ["/usr/libexec/tomcat/server", "start"]

--- a/container-images/foreman/Containerfile
+++ b/container-images/foreman/Containerfile
@@ -1,9 +1,11 @@
 FROM quay.io/centos/centos:stream9
 
-RUN dnf -y install \
+##Using rpm -ivh instead of dnf install for foreman-release.rpm speeds up the build
+##since foreman-release don't need to sync with the repos to install anything
+RUN rpm -ivh \
     https://yum.theforeman.org/nightly/el9/x86_64/foreman-release.rpm
-RUN dnf -y install foreman foreman-postgresql foreman-redis foreman-service
-RUN dnf clean all
+RUN dnf -y --nodocs install foreman foreman-postgresql foreman-redis foreman-service && \
+    dnf clean all
 
 COPY container-rake /usr/bin/container-rake
 


### PR DESCRIPTION
We can reduce the amount of disk required and layers for foreman and candlepin images

```
REPOSITORY                TAG         IMAGE ID      CREATED         SIZE
quay.io/ehelms/candlepin  4.4-test    41bbe74d7daa  11 seconds ago  1.3 GB
quay.io/ehelms/candlepin  4.4         cc37b39dce02  18 minutes ago  1.41 GB
```

```
REPOSITORY              TAG            IMAGE ID      CREATED         SIZE
quay.io/ehelms/foreman  nightly-layer  66760eacf2f9  18 minutes ago  459 MB
quay.io/ehelms/foreman  nightly        076654104b2d  31 minutes ago  585 MB
```

Why installing candlepin requires `pipewire-libs` o.O